### PR TITLE
Support any number of arguments

### DIFF
--- a/invariant.js
+++ b/invariant.js
@@ -44,7 +44,7 @@ var invariant = function(condition, format) {
       args.splice(0, 2);
 
       error = new Error(
-        format.replace(/%s/g, function (match) {
+        format.replace(/%s/g, function(match) {
           return args.length ? args.shift() : match;
         })
       );

--- a/invariant.js
+++ b/invariant.js
@@ -22,7 +22,9 @@
 
 var __DEV__ = process.env.NODE_ENV !== 'production';
 
-var invariant = function(condition, format, a, b, c, d, e, f) {
+var invariant = function(condition, format) {
+  var args = Array.prototype.slice.apply(arguments);
+
   if (__DEV__) {
     if (format === undefined) {
       throw new Error('invariant requires an error message argument');
@@ -37,11 +39,16 @@ var invariant = function(condition, format, a, b, c, d, e, f) {
         'for the full error message and additional helpful warnings.'
       );
     } else {
-      var args = [a, b, c, d, e, f];
-      var argIndex = 0;
+      // Remove `condition` and `format` from args array.
+      // We're left with an array of custom placeholder values (if any).
+      args.splice(0, 2);
+
       error = new Error(
-        format.replace(/%s/g, function() { return args[argIndex++]; })
+        format.replace(/%s/g, function (match) {
+          return args.length ? args.shift() : match;
+        })
       );
+
       error.name = 'Invariant Violation';
     }
 


### PR DESCRIPTION
- More robust argument handler. Now you can define any number of arguments to replace placeholders in the formatted string. Previously this was capped at six.
  
  ``` js
  invariant(false, '%s %s %s ... %s', 'one', 'two', 'three', ... 'n');
  // => 'one two three ... n'
  ```
- Like `console.log`, if the value for a placeholder is undefined, it won't try to populate the placeholder.
  
  Now:
  
  ``` js
  invariant(false, '%s %s', 'one');
  // => 'one %s'
  ```
  
  Previously:
  
  ``` js
  invariant(false, '%s %s', 'one');
  // => 'one undefined'
  ```
