### PR TITLE
Support for react-native

### DIFF
--- a/invariant.js
+++ b/invariant.js
@@ -20,10 +20,10 @@
  * will remain to ensure logic does not differ in production.
  */
 
-var __DEV__ = process.env.NODE_ENV !== 'production';
+var NODE_ENV = process.env.NODE_ENV;
 
 var invariant = function(condition, format, a, b, c, d, e, f) {
-  if (__DEV__) {
+  if (NODE_ENV !== 'production') {
     if (format === undefined) {
       throw new Error('invariant requires an error message argument');
     }


### PR DESCRIPTION
Setting the __DEV__ var causes release builds to fail on react native. I discovered this while using the react-intl library, which has a dependency on this library. So, I've removed usage of __DEV__ to make this library compatible with react-native. 