### PR TITLE
UMD wrapper

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -30,7 +30,7 @@
    */
 
   var invariant = function(condition, format, a, b, c, d, e, f) {
-    if (process.env.NODE_ENV !== 'production') {
+    if (typeof process === 'object' && process.env.NODE_ENV !== 'production') {
       if (format === undefined) {
         throw new Error('invariant requires an error message argument');
       }

--- a/browser.js
+++ b/browser.js
@@ -9,43 +9,53 @@
 
 'use strict';
 
-/**
- * Use invariant() to assert state which your program assumes to be true.
- *
- * Provide sprintf-style format (only %s is supported) and arguments
- * to provide information about what broke and what you were
- * expecting.
- *
- * The invariant message will be stripped in production, but the invariant
- * will remain to ensure logic does not differ in production.
- */
-
-var invariant = function(condition, format, a, b, c, d, e, f) {
-  if (process.env.NODE_ENV !== 'production') {
-    if (format === undefined) {
-      throw new Error('invariant requires an error message argument');
-    }
+(function(root, factory) {
+  if (typeof define === 'function' && define.amd) {
+    define([], factory);
+  } else if (typeof exports === 'object') {
+    module.exports = factory();
+  } else {
+    root.invariant = factory();
   }
+}(this, function($) {
+  /**
+   * Use invariant() to assert state which your program assumes to be true.
+   *
+   * Provide sprintf-style format (only %s is supported) and arguments
+   * to provide information about what broke and what you were
+   * expecting.
+   *
+   * The invariant message will be stripped in production, but the invariant
+   * will remain to ensure logic does not differ in production.
+   */
 
-  if (!condition) {
-    var error;
-    if (format === undefined) {
-      error = new Error(
-        'Minified exception occurred; use the non-minified dev environment ' +
-        'for the full error message and additional helpful warnings.'
-      );
-    } else {
-      var args = [a, b, c, d, e, f];
-      var argIndex = 0;
-      error = new Error(
-        format.replace(/%s/g, function() { return args[argIndex++]; })
-      );
-      error.name = 'Invariant Violation';
+  var invariant = function(condition, format, a, b, c, d, e, f) {
+    if (process.env.NODE_ENV !== 'production') {
+      if (format === undefined) {
+        throw new Error('invariant requires an error message argument');
+      }
     }
 
-    error.framesToPop = 1; // we don't care about invariant's own frame
-    throw error;
-  }
-};
+    if (!condition) {
+      var error;
+      if (format === undefined) {
+        error = new Error(
+          'Minified exception occurred; use the non-minified dev environment ' +
+          'for the full error message and additional helpful warnings.'
+        );
+      } else {
+        var args = [a, b, c, d, e, f];
+        var argIndex = 0;
+        error = new Error(
+          format.replace(/%s/g, function() { return args[argIndex++]; })
+        );
+        error.name = 'Invariant Violation';
+      }
 
-module.exports = invariant;
+      error.framesToPop = 1; // we don't care about invariant's own frame
+      throw error;
+    }
+  };
+
+  return invariant;
+}));


### PR DESCRIPTION
Hey @invariant,

Would love to use this great little Flow helper package on @github. But we're using an AMD based loader rather than CJS. Could the `browser.js` script be changed to use a more universal wrapper that supports AMD as well as CJS?

*(See [whitespace only diff](https://github.com/zertosh/invariant/pull/22/files?w=1))*

Thanks,
@josh