### PR TITLE
Change invariant Error.name

### DIFF
--- a/invariant.js
+++ b/invariant.js
@@ -42,7 +42,7 @@ var invariant = function(condition, format, a, b, c, d, e, f) {
       error = new Error(
         format.replace(/%s/g, function() { return args[argIndex++]; })
       );
-      error.name = 'Invariant Violation';
+      error.name = 'InvariantViolation';
     }
 
     error.framesToPop = 1; // we don't care about invariant's own frame


### PR DESCRIPTION
I think that "InvariantViolation" would be a more idiomatic name for this Error. https://developer.mozilla.org/pl/docs/Web/JavaScript/Referencje/Obiekty/Error/name

Maybe instead of using framesToPop you could use a name of error to pop frames from a stack.