### PR TITLE
Use spread operator to get the arguments more safely

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -18,7 +18,7 @@
  * will remain to ensure logic does not differ in production.
  */
 
-var invariant = function(condition, format, a, b, c, d, e, f) {
+var invariant = function(condition, format, ...args) {
   if (process.env.NODE_ENV !== 'production') {
     if (format === undefined) {
       throw new Error('invariant requires an error message argument');
@@ -33,7 +33,6 @@ var invariant = function(condition, format, a, b, c, d, e, f) {
         'for the full error message and additional helpful warnings.'
       );
     } else {
-      var args = [a, b, c, d, e, f];
       var argIndex = 0;
       error = new Error(
         format.replace(/%s/g, function() { return args[argIndex++]; })

--- a/invariant.js
+++ b/invariant.js
@@ -20,7 +20,7 @@
 
 var NODE_ENV = process.env.NODE_ENV;
 
-var invariant = function(condition, format, a, b, c, d, e, f) {
+var invariant = function(condition, format, ...args) {
   if (NODE_ENV !== 'production') {
     if (format === undefined) {
       throw new Error('invariant requires an error message argument');
@@ -35,7 +35,6 @@ var invariant = function(condition, format, a, b, c, d, e, f) {
         'for the full error message and additional helpful warnings.'
       );
     } else {
-      var args = [a, b, c, d, e, f];
       var argIndex = 0;
       error = new Error(
         format.replace(/%s/g, function() { return args[argIndex++]; })

--- a/invariant.js.flow
+++ b/invariant.js.flow
@@ -3,5 +3,5 @@
 declare module.exports: (
   condition: any,
   format?: string,
-  ...args: Array<any>
+  args?: Array<any>
 ) => void;


### PR DESCRIPTION
Hi @zertosh,

Don't know if this repo is still under maintainence. Anyway, I've noticed that it uses `a, b, c, d, e` as placeholders for the `%s` to be replaced. This could be easily improved by using the spread operator. It enhances the readability and is more safe in case **the length of the placeholders is more than 5**.

Would love to listen to your thought on this. 😄 