### PR TITLE
[travis] remove node 0.10/0.12, add 8/9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4.0"
   - "5"
   - "6"
   - "7"
+  - "8"
+  - "9"


### PR DESCRIPTION
No particular reason to drop the old versions except that nobody should be using them anymore.