### PR TITLE
 Move loose-envify to devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "devDependencies": {
     "browserify": "^11.0.1",
     "flow-bin": "^0.67.1",
+    "loose-envify": "^1.0.0",
     "tap": "^1.4.0"
   },
   "main": "invariant.js",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,6 @@
   "scripts": {
     "test": "NODE_ENV=production tap test/*.js && NODE_ENV=development tap test/*.js"
   },
-  "dependencies": {
-    "loose-envify": "^1.0.0"
-  },
   "devDependencies": {
     "browserify": "^11.0.1",
     "flow-bin": "^0.67.1",


### PR DESCRIPTION
This is only used for browserify which is only used in devDeps