### PR TITLE
Update flow-bin version to support aarch64

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "browserify": "^11.0.1",
-    "flow-bin": "^0.67.1",
+    "flow-bin": "^0.147.0",
     "tap": "^1.4.0"
   },
   "main": "invariant.js",

--- a/test/flow/.flowconfig
+++ b/test/flow/.flowconfig
@@ -16,4 +16,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.67.0
+^0.147.0

--- a/test/test.js
+++ b/test/test.js
@@ -36,6 +36,6 @@ test('flow', function(t) {
     cwd: path.join(__dirname, 'flow')
   }, function (err, stdout) {
     // If the types are broken, we'd have coverage below 100%
-    t.equal(stdout.trim(), 'Covered: 100.00% (5 of 5 expressions)');
+    t.equal(stdout.trim(), 'Covered: 100.00% (7 of 7 expressions)');
   });
 });


### PR DESCRIPTION
- Updated flow-bin version in package.json and .flowconfig files.
- Updated coverage to 7 expressions as it is increased with the latest flow-bin versions.