### PR TITLE
flow types: Make `format` argument required, like in implementation

### DIFF
--- a/invariant.js.flow
+++ b/invariant.js.flow
@@ -2,6 +2,6 @@
 
 declare module.exports: (
   condition: any,
-  format?: string,
+  format: string,
   ...args: Array<any>
 ) => void;


### PR DESCRIPTION
We throw an error when `format` is missing.

Fixes: #27